### PR TITLE
Improve ReqIF extension coverage

### DIFF
--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/AttributeDefinitionExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/AttributeDefinitionExtensionsTestFixture.cs
@@ -20,7 +20,10 @@
 
 namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 {
+    using System;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     using Microsoft.Extensions.Logging;
 
@@ -101,6 +104,22 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
         }
 
         [Test]
+        public void Verify_that_QueryDatatypeName_throws_when_input_is_null()
+        {
+            Assert.That(() => AttributeDefinitionExtensions.QueryDatatypeName(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_QueryDatatypeName_throws_when_type_is_not_supported()
+        {
+            var unsupportedAttributeDefinition = new UnsupportedAttributeDefinition();
+
+            Assert.That(
+                () => unsupportedAttributeDefinition.QueryDatatypeName(),
+                Throws.Exception.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
         public void Verify_that_QueryDefaultValueAsFormattedString_returns_expected_results()
         {
             var testDataCreator = new ReqIFTestDataCreator();
@@ -128,6 +147,96 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 
             var attributeDefinitionXHTML = (AttributeDefinitionXHTML)specType.SpecAttributes.Single(x => x.Identifier == "requirement-xhtml-attribute");
             Assert.That(attributeDefinitionXHTML.QueryDefaultValueAsFormattedString(), Is.EqualTo("NOT SET"));
+        }
+
+        [Test]
+        public void Verify_that_QueryDefaultValueAsFormattedString_returns_formatted_default_values()
+        {
+            var attributeDefinitionBoolean = new AttributeDefinitionBoolean
+            {
+                DefaultValue = new AttributeValueBoolean { TheValue = true }
+            };
+
+            Assert.That(attributeDefinitionBoolean.QueryDefaultValueAsFormattedString(), Is.EqualTo("True"));
+
+            var attributeDefinitionDate = new AttributeDefinitionDate
+            {
+                DefaultValue = new AttributeValueDate { TheValue = new DateTime(2020, 12, 25) }
+            };
+
+            Assert.That(attributeDefinitionDate.QueryDefaultValueAsFormattedString(), Is.EqualTo("December 25, 2020"));
+
+            var enumValue = new EnumValue { Identifier = "enum" };
+            var attributeDefinitionEnumeration = new AttributeDefinitionEnumeration
+            {
+                DefaultValue = new AttributeValueEnumeration()
+            };
+            attributeDefinitionEnumeration.DefaultValue.Values.Add(enumValue);
+
+            Assert.That(
+                attributeDefinitionEnumeration.QueryDefaultValueAsFormattedString(),
+                Is.EqualTo(enumValue.ToString()));
+
+            var attributeDefinitionInteger = new AttributeDefinitionInteger
+            {
+                DefaultValue = new AttributeValueInteger { TheValue = 42 }
+            };
+
+            Assert.That(attributeDefinitionInteger.QueryDefaultValueAsFormattedString(), Is.EqualTo("42"));
+
+            var attributeDefinitionReal = new AttributeDefinitionReal
+            {
+                DefaultValue = new AttributeValueReal { TheValue = 4.2 }
+            };
+
+            Assert.That(attributeDefinitionReal.QueryDefaultValueAsFormattedString(), Is.EqualTo("4.2"));
+
+            var attributeDefinitionString = new AttributeDefinitionString
+            {
+                DefaultValue = new AttributeValueString { TheValue = "value" }
+            };
+
+            Assert.That(attributeDefinitionString.QueryDefaultValueAsFormattedString(), Is.EqualTo("value"));
+
+            var attributeDefinitionXhtml = new AttributeDefinitionXHTML
+            {
+                DefaultValue = new AttributeValueXHTML { TheValue = "<xhtml:p>content</xhtml:p>" }
+            };
+
+            Assert.That(attributeDefinitionXhtml.QueryDefaultValueAsFormattedString(), Is.EqualTo("<xhtml:p>content</xhtml:p>"));
+        }
+
+        [Test]
+        public void Verify_that_QueryDefaultValueAsFormattedString_throws_when_input_is_null()
+        {
+            Assert.That(() => AttributeDefinitionExtensions.QueryDefaultValueAsFormattedString(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_QueryDefaultValueAsFormattedString_throws_when_type_is_not_supported()
+        {
+            var unsupportedAttributeDefinition = new UnsupportedAttributeDefinition();
+
+            Assert.That(
+                () => unsupportedAttributeDefinition.QueryDefaultValueAsFormattedString(),
+                Throws.Exception.TypeOf<InvalidOperationException>());
+        }
+
+        private class UnsupportedAttributeDefinition : AttributeDefinition
+        {
+            protected override DatatypeDefinition GetDatatypeDefinition()
+            {
+                return null;
+            }
+
+            protected override void SetDatatypeDefinition(DatatypeDefinition datatypeDefinition)
+            {
+            }
+
+            internal override Task ReadXmlAsync(System.Xml.XmlReader reader, CancellationToken token)
+            {
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/AttributeValueExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/AttributeValueExtensionsTestFixture.cs
@@ -20,7 +20,11 @@
 
 namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 {
+    using System;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     using NUnit.Framework;
 
@@ -62,6 +66,80 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 
             var attributeValueXhtml = specObject.Values.OfType<AttributeValueXHTML>().First();
             Assert.That(attributeValueXhtml.QueryFormattedValue(), Is.EqualTo("<xhtml:p>XhtmlPType<xhtml:a accesskey=\"a\" charset=\"UTF-8\" href=\"http://eclipse.org/rmf\" hreflang=\"en\" rel=\"LinkTypes\" rev=\"LinkTypes\" style=\"text-decoration:underline\" tabindex=\"1\" title=\"text\" type=\"text/html\"> text before br<xhtml:br/>text after br text before span<xhtml:span>XhtmlSpanType</xhtml:span>text after span text before em<xhtml:em>XhtmlEmType</xhtml:em>text after em text before strong<xhtml:strong>XhtmlStrongType</xhtml:strong>text after strong text before dfn<xhtml:dfn>XhtmlDfnType</xhtml:dfn>text after dfn text before code<xhtml:code>XhtmlCodeType</xhtml:code>text after code text before samp<xhtml:samp>XhtmlSampType</xhtml:samp>text after samp text before kbd<xhtml:kbd>XhtmlKbdType</xhtml:kbd>text after kbd text before var<xhtml:var>XhtmlVarType</xhtml:var>text after var text before cite<xhtml:cite>XhtmlCiteType</xhtml:cite>text after cite text before abbr<xhtml:abbr>XhtmlAbbrType</xhtml:abbr>text after abbr text before acronym<xhtml:acronym>XhtmlAcronymType</xhtml:acronym>text after acronym text before q<xhtml:q>XhtmlQType</xhtml:q>text after q text before tt<xhtml:tt>XhtmlInlPresType</xhtml:tt>text after tt text before i<xhtml:i>XhtmlInlPresType</xhtml:i>text after i text before b<xhtml:b>XhtmlInlPresType</xhtml:b>text after b text before big<xhtml:big>XhtmlInlPresType</xhtml:big>text after big text before small<xhtml:small>XhtmlInlPresType</xhtml:small>text after small text before sub<xhtml:sub>XhtmlInlPresType</xhtml:sub>text after sub text before sup<xhtml:sup>XhtmlInlPresType</xhtml:sup>text after sup text before ins<xhtml:ins>XhtmlEditType</xhtml:ins>text after ins text before del<xhtml:del>XhtmlEditType</xhtml:del>text after del</xhtml:a></xhtml:p>"));
+        }
+
+        [Test]
+        public void Verify_that_QueryFormattedValue_joins_multiple_enumeration_values()
+        {
+            var enumerationValueA = new EnumValue
+            {
+                Properties = new EmbeddedValue { OtherContent = "A" }
+            };
+
+            var enumerationValueB = new EnumValue
+            {
+                Properties = new EmbeddedValue { OtherContent = "B" }
+            };
+
+            var attributeValueEnumeration = new AttributeValueEnumeration();
+            attributeValueEnumeration.Values.Add(enumerationValueA);
+            attributeValueEnumeration.Values.Add(enumerationValueB);
+
+            Assert.That(attributeValueEnumeration.QueryFormattedValue(), Is.EqualTo("A;B"));
+        }
+
+        [Test]
+        public void Verify_that_QueryFormattedValue_throws_when_attributeValue_is_null()
+        {
+            Assert.That(() => AttributeValueExtensions.QueryFormattedValue(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_QueryFormattedValue_throws_when_type_is_not_supported()
+        {
+            var unsupportedAttributeValue = new UnsupportedAttributeValue();
+
+            Assert.That(
+                () => unsupportedAttributeValue.QueryFormattedValue(),
+                Throws.Exception.TypeOf<InvalidOperationException>());
+        }
+
+        private class UnsupportedAttributeValue : AttributeValue
+        {
+            public override object ObjectValue
+            {
+                get => null;
+                set
+                {
+                }
+            }
+
+            protected override AttributeDefinition GetAttributeDefinition()
+            {
+                return null;
+            }
+
+            protected override void SetAttributeDefinition(AttributeDefinition attributeDefinition)
+            {
+            }
+
+            internal override void ReadXml(System.Xml.XmlReader reader)
+            {
+            }
+
+            internal override Task ReadXmlAsync(System.Xml.XmlReader reader, CancellationToken token)
+            {
+                return Task.CompletedTask;
+            }
+
+            internal override void WriteXml(System.Xml.XmlWriter writer)
+            {
+            }
+
+            internal override Task WriteXmlAsync(System.Xml.XmlWriter writer, CancellationToken token)
+            {
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/RelationGroupTypeExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/RelationGroupTypeExtensionsTestFixture.cs
@@ -25,6 +25,7 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 
     using NUnit.Framework;
 
+    using ReqIFSharp;
     using ReqIFSharp.Extensions.ReqIFExtensions;
     using ReqIFSharp.Extensions.Tests.TestData;
 
@@ -52,6 +53,35 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
             var specObjects = relationGroupType.QueryReferencingRelationGroups();
 
             Assert.That(specObjects.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Verify_that_QueryReferencingRelationGroups_returns_empty_when_none_reference_type()
+        {
+            var reqIf = new ReqIF
+            {
+                CoreContent = new ReqIFContent()
+            };
+
+            var relationGroupType = new RelationGroupType { ReqIFContent = reqIf.CoreContent };
+            var otherRelationGroupType = new RelationGroupType { ReqIFContent = reqIf.CoreContent };
+
+            var relationGroup = new RelationGroup(reqIf.CoreContent, null)
+            {
+                Type = otherRelationGroupType
+            };
+
+            reqIf.CoreContent.SpecRelationGroups.Add(relationGroup);
+
+            var result = relationGroupType.QueryReferencingRelationGroups();
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QueryReferencingRelationGroups_throws_when_relationGroupType_is_null()
+        {
+            Assert.That(() => RelationGroupTypeExtensions.QueryReferencingRelationGroups(null), Throws.ArgumentNullException);
         }
 
         [Test]

--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecElementWithAttributesExtensionTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecElementWithAttributesExtensionTestFixture.cs
@@ -20,6 +20,8 @@
 
 namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 {
+    using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Threading;
@@ -70,6 +72,27 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
         }
 
         [Test]
+        public void Verify_that_QueryExternalObjects_returns_empty_when_no_external_objects_are_present()
+        {
+            var specObject = new SpecObject
+            {
+                Values =
+                {
+                    new AttributeValueBoolean(),
+                    new AttributeValueString()
+                }
+            };
+
+            Assert.That(specObject.QueryExternalObjects(), Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QueryExternalObjects_throws_when_specElement_is_null()
+        {
+            Assert.That(() => SpecElementWithAttributesExtensions.QueryExternalObjects(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
         public async Task Verify_that_QueryBase64Payloads_returns_expected_results()
         {
             var specObject = this.reqIf.CoreContent.SpecObjects.Single(x => x.Identifier == "_3.4.2.2.2_BrLeft_2_BrRight_._BrLeft_f_BrRight_1");
@@ -79,6 +102,135 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
             var base64Payload = base64Payloads.Single();
 
             Assert.That(base64Payload.Item2, Does.StartWith("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAfgAAACfCAIAAACazFx+AAAAAXNSR0IArs4c6QAA"));
+        }
+
+        [Test]
+        public void Verify_that_QueryBase64PayloadsAsync_throws_when_specElement_is_null()
+        {
+            Assert.That(
+                () => SpecElementWithAttributesExtensions.QueryBase64PayloadsAsync(null, this.reqIFLoaderService),
+                Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_QueryBase64PayloadsAsync_throws_when_loader_is_null()
+        {
+            var specObject = this.reqIf.CoreContent.SpecObjects.First();
+
+            Assert.That(() => specObject.QueryBase64PayloadsAsync(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public async Task Verify_that_QueryBase64PayloadsAsync_returns_payloads_for_all_external_objects()
+        {
+            var specObject = new SpecObject
+            {
+                Values =
+                {
+                    new AttributeValueXHTML
+                    {
+                        ExternalObjects =
+                        {
+                            new ExternalObject { Identifier = "object-1" },
+                            new ExternalObject { Identifier = "object-2" }
+                        }
+                    },
+                    new AttributeValueXHTML
+                    {
+                        ExternalObjects =
+                        {
+                            new ExternalObject { Identifier = "object-3" }
+                        }
+                    }
+                }
+            };
+
+            var loader = new StubReqIfLoaderService();
+
+            var payloads = await specObject.QueryBase64PayloadsAsync(loader);
+
+            Assert.That(payloads.Select(x => x.Item1.Identifier), Is.EquivalentTo(new[] { "object-1", "object-2", "object-3" }));
+            Assert.That(payloads.Select(x => x.Item2), Is.EquivalentTo(new[] { "payload-object-1", "payload-object-2", "payload-object-3" }));
+        }
+
+        [Test]
+        public void Verify_that_ReqIFContent_QueryExternalObjects_returns_expected_results()
+        {
+            var reqIfContent = new ReqIFContent();
+
+            var specObject = new SpecObject
+            {
+                ReqIFContent = reqIfContent,
+                Values =
+                {
+                    new AttributeValueXHTML
+                    {
+                        ExternalObjects =
+                        {
+                            new ExternalObject { Identifier = "object-1" }
+                        }
+                    }
+                }
+            };
+
+            var specRelation = new SpecRelation
+            {
+                ReqIFContent = reqIfContent,
+                Values =
+                {
+                    new AttributeValueXHTML
+                    {
+                        ExternalObjects =
+                        {
+                            new ExternalObject { Identifier = "object-2" }
+                        }
+                    }
+                }
+            };
+
+            reqIfContent.SpecObjects.Add(specObject);
+            reqIfContent.SpecRelations.Add(specRelation);
+
+            var externalObjects = reqIfContent.QueryExternalObjects().ToList();
+
+            Assert.That(externalObjects.Select(x => x.Identifier), Is.EquivalentTo(new[] { "object-1", "object-2" }));
+        }
+
+        [Test]
+        public void Verify_that_ReqIFContent_QueryExternalObjects_throws_when_reqIfContent_is_null()
+        {
+            Assert.That(() => ReqIFContentExtensions.QueryExternalObjects(null), Throws.ArgumentNullException);
+        }
+
+        private class StubReqIfLoaderService : IReqIFLoaderService
+        {
+            public IEnumerable<ReqIF> ReqIFData => throw new NotImplementedException();
+
+            public event EventHandler<IEnumerable<ReqIF>> ReqIfChanged
+            {
+                add => throw new NotImplementedException();
+                remove => throw new NotImplementedException();
+            }
+
+            public Task<Stream> GetSourceStreamAsync(CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task LoadAsync(Stream reqifStream, SupportedFileExtensionKind fileExtensionKind, CancellationToken token)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<string> QueryDataAsync(ExternalObject externalObject, CancellationToken token)
+            {
+                return Task.FromResult($"payload-{externalObject.Identifier}");
+            }
+
+            public void Reset()
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecObjectExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecObjectExtensionsTestFixture.cs
@@ -25,6 +25,7 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 
     using NUnit.Framework;
 
+    using ReqIFSharp;
     using ReqIFSharp.Extensions.ReqIFExtensions;
 
     /// <summary>
@@ -76,11 +77,28 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
         }
 
         [Test]
+        public void Verify_that_QueryContainerSpecifications_returns_empty_when_specObject_not_in_specification()
+        {
+            var specObject = new SpecObject
+            {
+                ReqIFContent = this.reqIf.CoreContent
+            };
+
+            Assert.That(specObject.QueryContainerSpecifications(), Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QueryContainerSpecifications_throws_when_specObject_is_null()
+        {
+            Assert.That(() => SpecObjectExtensions.QueryContainerSpecifications(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
         public void Verify_that_when_ReqIFContent_is_null_exception_is_thrown()
         {
             this.specObject = new SpecObject();
 
-            Assert.That(() => this.specObject.QueryContainerSpecifications(), 
+            Assert.That(() => this.specObject.QueryContainerSpecifications(),
                 Throws.TypeOf<InvalidOperationException>());
         }
 
@@ -90,6 +108,41 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
             var specRelations = this.specObject.QuerySpecRelations();
 
             Assert.That(specRelations.Single(), Is.EqualTo(this.specRelation));
+        }
+
+        [Test]
+        public void Verify_that_QuerySpecRelations_returns_results_when_specObject_is_target()
+        {
+            var targetSpecObject = new SpecObject(this.reqIf.CoreContent, null)
+            {
+                Identifier = "target"
+            };
+
+            var specRelation = new SpecRelation(this.reqIf.CoreContent, null)
+            {
+                Target = targetSpecObject
+            };
+
+            var specRelations = targetSpecObject.QuerySpecRelations();
+
+            Assert.That(specRelations.Single(), Is.EqualTo(specRelation));
+        }
+
+        [Test]
+        public void Verify_that_QuerySpecRelations_returns_empty_when_no_relations_exist()
+        {
+            var specObject = new SpecObject
+            {
+                ReqIFContent = this.reqIf.CoreContent
+            };
+
+            Assert.That(specObject.QuerySpecRelations(), Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QuerySpecRelations_throws_when_specObject_is_null()
+        {
+            Assert.That(() => SpecObjectExtensions.QuerySpecRelations(null), Throws.ArgumentNullException);
         }
     }
 }

--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecObjectTypeExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecObjectTypeExtensionsTestFixture.cs
@@ -25,6 +25,7 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 
     using NUnit.Framework;
 
+    using ReqIFSharp;
     using ReqIFSharp.Extensions.ReqIFExtensions;
     using ReqIFSharp.Extensions.Tests.TestData;
 
@@ -55,10 +56,39 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
         }
 
         [Test]
+        public void Verify_that_QueryReferencingSpecObject_returns_empty_when_none_reference_type()
+        {
+            var reqIf = new ReqIF
+            {
+                CoreContent = new ReqIFContent()
+            };
+
+            var specObjectType = new SpecObjectType { ReqIFContent = reqIf.CoreContent };
+            var otherSpecObjectType = new SpecObjectType { ReqIFContent = reqIf.CoreContent };
+
+            var specObject = new SpecObject(reqIf.CoreContent, null)
+            {
+                Type = otherSpecObjectType
+            };
+
+            reqIf.CoreContent.SpecObjects.Add(specObject);
+
+            var result = specObjectType.QueryReferencingSpecObjects();
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QueryReferencingSpecObject_throws_when_specObjectType_is_null()
+        {
+            Assert.That(() => SpecObjectTypeExtensions.QueryReferencingSpecObjects(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
         public void Verify_that_on_QueryReferencingSpecifications_NullReferenceException_is_thrown_when_owning_ReqIFContent_is_not_set()
         {
             var specObjectType = new SpecObjectType();
-            
+
             Assert.That(() => specObjectType.QueryReferencingSpecObjects(),
                 Throws.Exception.TypeOf<InvalidOperationException>()
                     .With.Message.Contains("The owning ReqIFContent of the SpecObjectType is not set."));

--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecRelationTypeExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecRelationTypeExtensionsTestFixture.cs
@@ -25,6 +25,7 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 
     using NUnit.Framework;
 
+    using ReqIFSharp;
     using ReqIFSharp.Extensions.ReqIFExtensions;
     using ReqIFSharp.Extensions.Tests.TestData;
 
@@ -52,6 +53,35 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
             var specObjects = specRelationType.QueryReferencingSpecRelations();
 
             Assert.That(specObjects.Count(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Verify_that_QueryReferencingSpecRelations_returns_empty_when_none_reference_type()
+        {
+            var reqIf = new ReqIF
+            {
+                CoreContent = new ReqIFContent()
+            };
+
+            var specRelationType = new SpecRelationType { ReqIFContent = reqIf.CoreContent };
+            var otherSpecRelationType = new SpecRelationType { ReqIFContent = reqIf.CoreContent };
+
+            var specRelation = new SpecRelation(reqIf.CoreContent, null)
+            {
+                Type = otherSpecRelationType
+            };
+
+            reqIf.CoreContent.SpecRelations.Add(specRelation);
+
+            var result = specRelationType.QueryReferencingSpecRelations();
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QueryReferencingSpecRelations_throws_when_specRelationType_is_null()
+        {
+            Assert.That(() => SpecRelationTypeExtensions.QueryReferencingSpecRelations(null), Throws.ArgumentNullException);
         }
 
         [Test]

--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecificationExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecificationExtensionsTestFixture.cs
@@ -65,6 +65,35 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
         }
 
         [Test]
+        public void Verify_that_QuerySpecHierarchies_throws_when_specification_is_null()
+        {
+            Assert.That(() => SpecificationExtensions.QueryAllContainedSpecHierarchies(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_SpecHierarchy_QueryAllContainedSpecHierarchies_returns_expected_results()
+        {
+            var rootHierarchy = new SpecHierarchy();
+            var childHierarchy = new SpecHierarchy();
+            var grandChildHierarchy = new SpecHierarchy();
+
+            rootHierarchy.Children.Add(childHierarchy);
+            childHierarchy.Children.Add(grandChildHierarchy);
+
+            var result = rootHierarchy.QueryAllContainedSpecHierarchies();
+
+            Assert.That(result, Is.EquivalentTo(new[] { childHierarchy, grandChildHierarchy }));
+        }
+
+        [Test]
+        public void Verify_that_QueryAllContainedSpecObjects_returns_the_expected_results()
+        {
+            var specification = this.reqIf.CoreContent.Specifications.Single(x => x.Identifier == "_o7scS6dbEeafNduaIhMwQg");
+
+            Assert.That(specification.QueryAllContainedSpecObjects().Count(), Is.EqualTo(13));
+        }
+
+        [Test]
         public void Verify_that_QueryAttributeDefinitions_returns_the_expected_results()
         {
             var specification = this.reqIf.CoreContent.Specifications.Single(x => x.Identifier == "_o7scS6dbEeafNduaIhMwQg");
@@ -76,6 +105,18 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
             Assert.That(attributeDefinitions.Single(x => x.Identifier == "_o7scPKdbEeafNduaIhMwQg"), Is.Not.Null);
             Assert.That(attributeDefinitions.Single(x => x.Identifier == "_o7scPadbEeafNduaIhMwQg"), Is.Not.Null);
             Assert.That(attributeDefinitions.Single(x => x.Identifier == "_o7scO6dbEeafNduaIhMwQg"), Is.Not.Null);
+        }
+
+        [Test]
+        public void Verify_that_QueryAttributeDefinitions_throws_when_specification_is_null()
+        {
+            Assert.That(() => SpecificationExtensions.QueryAttributeDefinitions(null), Throws.ArgumentNullException);
+        }
+
+        [Test]
+        public void Verify_that_SpecHierarchy_QueryAllContainedSpecHierarchies_throws_when_specHierarchy_is_null()
+        {
+            Assert.That(() => SpecHierarchyExtensions.QueryAllContainedSpecHierarchies(null), Throws.ArgumentNullException);
         }
     }
 }

--- a/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecificationTypeExtensionsTestFixture.cs
+++ b/ReqIFSharp.Extensions.Tests/ReqIFExtensions/SpecificationTypeExtensionsTestFixture.cs
@@ -25,6 +25,7 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
 
     using NUnit.Framework;
 
+    using ReqIFSharp;
     using ReqIFSharp.Extensions.ReqIFExtensions;
     using ReqIFSharp.Extensions.Tests.TestData;
 
@@ -52,6 +53,35 @@ namespace ReqIFSharp.Extensions.Tests.ReqIFExtensions
             var specObjects = specificationType.QueryReferencingSpecifications();
 
             Assert.That(specObjects.Count(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Verify_that_QueryReferencingSpecifications_returns_empty_when_none_reference_type()
+        {
+            var reqIf = new ReqIF
+            {
+                CoreContent = new ReqIFContent()
+            };
+
+            var specificationType = new SpecificationType { ReqIFContent = reqIf.CoreContent };
+            var otherSpecificationType = new SpecificationType { ReqIFContent = reqIf.CoreContent };
+
+            var specification = new Specification(reqIf.CoreContent, null)
+            {
+                Type = otherSpecificationType
+            };
+
+            reqIf.CoreContent.Specifications.Add(specification);
+
+            var result = specificationType.QueryReferencingSpecifications();
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void Verify_that_QueryReferencingSpecifications_throws_when_specificationType_is_null()
+        {
+            Assert.That(() => SpecificationTypeExtensions.QueryReferencingSpecifications(null), Throws.ArgumentNullException);
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- expand coverage of ReqIF extension helper tests with null-check, error, and positive scenarios
- add new cases for querying defaults, formatted values, and relation/specification lookups
- validate ReqIF content aggregation and SpecHierarchy recursion utilities

## Testing
- unable to run tests (dotnet not installed in container)

------
https://chatgpt.com/codex/tasks/task_e_68e11004c2a88326aec08bc126e701db